### PR TITLE
Chore - Pin the version of Github Actions OS

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   web-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read
@@ -36,7 +36,7 @@ jobs:
           docker compose --file ./docker/docker-compose.yaml up web-test --exit-code-from web-test --build --remove-orphans
 
   api-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read


### PR DESCRIPTION
Github Actions displayed a warning:
![image](https://github.com/user-attachments/assets/8ff0bc1d-9a96-456e-96cf-f9eb4adaa595)

Instead of using `latest`, we should pin the version to avoid unexpected changes.