### PR TITLE
Chore - Share the same build for `dotnet test` and `dotnet publish`

### DIFF
--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -7,18 +7,20 @@ USER app
 COPY --chown=app:app *.sln .
 COPY --chown=app:app ./src ./src
 COPY --chown=app:app ./tests ./tests
+
+RUN dotnet clean ./src/API --output ./bin
 RUN dotnet restore
+RUN dotnet build --configuration Release --no-restore
 
 ################################################
 
 FROM base AS test
-ENTRYPOINT ["dotnet", "test", "--no-restore"]
+ENTRYPOINT ["dotnet", "test", "--configuration", "Release", "--no-build"]
 
 ################################################
 
-FROM base AS build
-RUN dotnet clean ./src/API --output ./bin
-RUN dotnet publish ./src/API --configuration Release --output ./bin --no-restore
+FROM base AS publish
+RUN dotnet publish ./src/API --output ./bin --no-build
 
 ################################################
 
@@ -26,5 +28,5 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS production
 WORKDIR /app/bin
 USER app
 
-COPY --from=build /app/bin /app/bin
+COPY --from=publish /app/bin /app/bin
 ENTRYPOINT ["dotnet", "API.dll"]

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -8,8 +8,8 @@ COPY --chown=app:app *.sln .
 COPY --chown=app:app ./src ./src
 COPY --chown=app:app ./tests ./tests
 
-RUN dotnet clean ./src/API --output ./bin
 RUN dotnet restore
+RUN dotnet clean ./src/API --output ./bin
 RUN dotnet build --configuration Release --no-restore
 
 ################################################

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -20,7 +20,7 @@ ENTRYPOINT ["dotnet", "test", "--configuration", "Release", "--no-build"]
 ################################################
 
 FROM base AS publish
-RUN dotnet publish ./src/API --output ./bin --no-build
+RUN dotnet publish --configuration Release ./src/API --output ./bin --no-build
 
 ################################################
 


### PR DESCRIPTION
As a DevOps engineer
I want to make `dotnet test` and `dotnet publish` use the same build
so that I am confident that the tested build is being deployed.