### PR TITLE
DevOps - Skip pipeline run when only `.vscode` folder is updated

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -8,6 +8,7 @@ on:
       - "LICENCE"
       - "README.md"
       - "./readme"
+      - "./.vscode/**"
 
 jobs:
   run-unit-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
       - "LICENCE"
       - "README.md"
       - "./readme"
+      - "./.vscode/**"
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
As a DevOps engineer
I want to skip pipeline run for certain folders
so that unnecessary runs can be avoided and resources can be saved.