### PR TITLE
DevOps - Remove `paths-ignore` from Github Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - "main"
-    paths-ignore:
-      - "LICENCE"
-      - "README.md"
-      - "readme/**"
-      - ".vscode/**"
 
 jobs:
   run-unit-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - "main"
-    paths-ignore:
-      - "LICENCE"
-      - "README.md"
-      - "readme/**"
-      - ".vscode/**"
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
Reverting https://github.com/samuelko123/price-alert/pull/18 and https://github.com/samuelko123/price-alert/pull/19.

It is noticed that required status check would hang when Github Action is skipped due to path filtering.

A feature request has been submitted to Github:
https://github.com/orgs/community/discussions/44490

Meanwhile, we have no choice but to remove `paths-ignore`