### PR TITLE
DevOps - Split docker compose files

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build Docker images
         run: |
-          docker compose --file ./infra/docker/docker-compose.yaml --profile production build
+          docker compose --file ./infra/docker/docker-compose.yaml build
 
       - name: Push Docker images
         run: |
-          docker compose --file ./infra/docker/docker-compose.yaml --profile production push
+          docker compose --file ./infra/docker/docker-compose.yaml push

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          docker compose --file ./infra/docker/docker-compose.yaml up web-test --exit-code-from web-test --build --remove-orphans
+          docker compose --file ./infra/docker/docker-compose.test.yaml up web-test --exit-code-from web-test --build --remove-orphans
 
   api-test:
     name: API Test
@@ -36,4 +36,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          docker compose --file ./infra/docker/docker-compose.yaml up api-test --exit-code-from api-test --build --remove-orphans
+          docker compose --file ./infra/docker/docker-compose.test.yaml up api-test --exit-code-from api-test --build --remove-orphans

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ docker compose --file ./infra/docker/docker-compose.yaml --profile production up
 <h2>How to Run Unit Test</h2>
 
 ```
-docker compose --file ./infra/docker/docker-compose.yaml --profile test up --build --remove-orphans
+docker compose --file ./infra/docker/docker-compose.test.yaml up --build --remove-orphans
 ```
 
 <h2>Further Readings</h2>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <h2>How to Run Locally</h2>
 
 ```
-docker compose --file ./infra/docker/docker-compose.yaml --profile production up --build --remove-orphans
+docker compose --file ./infra/docker/docker-compose.yaml up --build --remove-orphans
 ```
 
 <p>Then, go to http://localhost:4000/</p>

--- a/infra/docker/docker-compose.test.yaml
+++ b/infra/docker/docker-compose.test.yaml
@@ -1,0 +1,14 @@
+name: price-alert-test
+services:
+  web-test:
+    container_name: web-test
+    build:
+      context: ../../web/
+      dockerfile: ../infra/docker/web.Dockerfile
+      target: test
+  api-test:
+    container_name: api-test
+    build:
+      context: ../../backend/PriceAlert
+      dockerfile: ../../infra/docker/api.Dockerfile
+      target: test

--- a/infra/docker/docker-compose.yaml
+++ b/infra/docker/docker-compose.yaml
@@ -14,8 +14,6 @@ services:
       interval: 5m
       start_period: 30s
       start_interval: 1s
-    profiles:
-      - production
   web:
     container_name: web
     image: samuelko123/price-alert-web:latest
@@ -32,8 +30,6 @@ services:
       interval: 5m
       start_period: 30s
       start_interval: 1s
-    profiles:
-      - production
   reverse-proxy:
     container_name: reverse-proxy
     image: samuelko123/price-alert-reverse-proxy:latest
@@ -51,5 +47,3 @@ services:
       - app_protocol: http
         target: 4000
         published: 4000
-    profiles:
-      - production

--- a/infra/docker/docker-compose.yaml
+++ b/infra/docker/docker-compose.yaml
@@ -1,21 +1,5 @@
 name: price-alert
 services:
-  web-test:
-    container_name: web-test
-    build:
-      context: ../../web/
-      dockerfile: ../infra/docker/web.Dockerfile
-      target: test
-    profiles:
-      - test
-  api-test:
-    container_name: api-test
-    build:
-      context: ../../backend/PriceAlert
-      dockerfile: ../../infra/docker/api.Dockerfile
-      target: test
-    profiles:
-      - test
   api:
     container_name: api
     image: samuelko123/price-alert-api:latest
@@ -26,7 +10,7 @@ services:
     environment:
       ASPNETCORE_HTTP_PORTS: 5000
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:5000/api/healthcheck"]
+      test: [ "CMD", "curl", "--fail", "http://localhost:5000/api/healthcheck" ]
       interval: 5m
       start_period: 30s
       start_interval: 1s
@@ -44,7 +28,7 @@ services:
       dockerfile: ../infra/docker/web.Dockerfile
       target: production
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000"]
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000" ]
       interval: 5m
       start_period: 30s
       start_interval: 1s

--- a/infra/terraform/digital_ocean_droplet_init.yaml
+++ b/infra/terraform/digital_ocean_droplet_init.yaml
@@ -31,8 +31,8 @@ write_files:
       #!/usr/bin/env bash
       mkdir -p /app
       wget --output-document=/app/docker-compose.yaml https://raw.githubusercontent.com/samuelko123/price-alert/refs/heads/main/infra/docker/docker-compose.yaml
-      docker compose --file /app/docker-compose.yaml --profile production pull
-      docker compose --file /app/docker-compose.yaml --profile production up --detach --remove-orphans
+      docker compose --file /app/docker/docker-compose.yaml pull
+      docker compose --file /app/docker/docker-compose.yaml up --detach --remove-orphans
 
   - path: /scripts/install-webhook.sh
     permissions: '0700'


### PR DESCRIPTION
Currently, `--profile test` and `--profile production` are completely unrelated stuff being put together in one `docker-compose.yaml`.

Splitting it into two files means easier management.