### PR TITLE
DevOps - Remove old Docker images from server

### DIFF
--- a/infra/terraform/digital_ocean_droplet_init.yaml
+++ b/infra/terraform/digital_ocean_droplet_init.yaml
@@ -31,8 +31,9 @@ write_files:
       #!/usr/bin/env bash
       mkdir -p /app
       wget --output-document=/app/docker-compose.yaml https://raw.githubusercontent.com/samuelko123/price-alert/refs/heads/main/infra/docker/docker-compose.yaml
-      docker compose --file /app/docker/docker-compose.yaml pull
-      docker compose --file /app/docker/docker-compose.yaml up --detach --remove-orphans
+      docker compose --file /app/docker-compose.yaml pull
+      docker compose --file /app/docker-compose.yaml up --detach --remove-orphans
+      docker system prune --force
 
   - path: /scripts/install-webhook.sh
     permissions: '0700'


### PR DESCRIPTION
It is discovered that the server disk is full.
When we pull new images from DockerHub, the old images are left on disk.
Therefore, added `docker system prune` as the last step of deployment.