### PR TITLE
Dev - Fix `permission denied` issue on dev mode

### DIFF
--- a/infra/docker/api.Dockerfile
+++ b/infra/docker/api.Dockerfile
@@ -13,6 +13,12 @@ COPY --chown=app:app *.sln .
 COPY --chown=app:app ./src ./src
 COPY --chown=app:app ./tests ./tests
 
+RUN mkdir -p /app/src/PriceAlert/bin
+RUN chown app:app /app/src/PriceAlert/bin
+
+RUN mkdir -p /app/src/PriceAlert/obj
+RUN chown app:app /app/src/PriceAlert/obj
+
 ################################################
 
 FROM base AS development


### PR DESCRIPTION
After running `./run.ps1 uninstall` and `./run.ps1 dev`, it is observed that permission is denied for the `api-dev` container:
![image](https://github.com/user-attachments/assets/f6bc2d48-ba9a-406c-8db0-ec3d62357bff)

This PR is based on [this answer](https://stackoverflow.com/questions/64027052/docker-compose-and-named-volume-permission-denied).